### PR TITLE
Allow a space before floats, ints and coordinates

### DIFF
--- a/coffee/sentence_wizard.coffee
+++ b/coffee/sentence_wizard.coffee
@@ -141,12 +141,12 @@ guess_field_type = (fs, index) ->
 
     if index is 2 or index is 3
         name = if index is 2 then "latitude" else "longitude"
-        if /^(-|\+|)[0-9]{1,3}\.[0-9]{4,8}$/.test fs
+        if /^(-|\+| |)[0-9]{1,3}\.[0-9]{4,8}$/.test fs
             return sensor: "stdtelem.coordinate", format: "dd.dddd", name: name
-        if /^(-|\+|)[0-9]{1,3}[0-5][0-9]\.[0-9]{2,6}$/.test fs
+        if /^(-|\+| |)[0-9]{1,3}[0-5][0-9]\.[0-9]{2,6}$/.test fs
             return sensor: "stdtelem.coordinate", format: "ddmm.mmmm", name: name
 
-    if /^(-|\+|)[0-9]+$/.test fs
+    if /^(-|\+| |)[0-9]+$/.test fs
         name = switch index
             when 0 then "sentence_id"
             when 4 then "altitude"
@@ -154,7 +154,7 @@ guess_field_type = (fs, index) ->
 
         return sensor: "base.ascii_int", name: name
 
-    if /^(-|\+|)[0-9]+\.[0-9]+$/.test fs
+    if /^(-|\+| |)[0-9]+\.[0-9]+$/.test fs
         name = if index is 4 then "altitude" else ""
         return sensor: "base.ascii_float", name: ""
 
@@ -164,7 +164,7 @@ guess_field_type = (fs, index) ->
 plausible_field_types = (fs) ->
     results = ["base.string", "base.constant"]
     if time_regex.test fs then results.push "stdtelem.time"
-    if (/^(-|\+|)[0-9\.]+$/.test fs) and not isNaN(strict_numeric fs)
+    if (/^(-|\+| |)[0-9\.]+$/.test fs) and not isNaN(strict_numeric fs)
         if (fs.indexOf '.') == -1
             results.push "base.ascii_int"
         else


### PR DESCRIPTION
e.g., `$$CRAAG1,2,000000,0,0,0,0,B,2.78, 21.9, 21.7*51B5`
the genpayload wizard used to forbid using the float type for the temperature fields
